### PR TITLE
Fix no auto encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ coverage
 # AMF models
 /demo/*.json
 !demo/apis.json
+
+.idea

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -3,5 +3,6 @@
   "APIC-168/APIC-168.raml": "RAML 1.0",
   "annotated-oauth2/annotated-oauth2.raml": "RAML 1.0",
   "APIC-298/APIC-298.json": ["OAS 2.0", "application/json"],
-  "APIC-289/APIC-289.yaml": ["OAS 2.0", "application/yaml"]
+  "APIC-289/APIC-289.yaml": ["OAS 2.0", "application/yaml"],
+  "no-auto-encoding/no-auto-encoding.raml": "RAML 1.0"
 }

--- a/demo/no-auto-encoding/no-auto-encoding.raml
+++ b/demo/no-auto-encoding/no-auto-encoding.raml
@@ -3,7 +3,6 @@ title: No auto encoding API
 version: v1
 baseUri: http://{baseUri}
 baseUriParameters:
-  (no-auto-encoding):
   baseUri:
     (no-auto-encoding):
     enum:

--- a/demo/no-auto-encoding/no-auto-encoding.raml
+++ b/demo/no-auto-encoding/no-auto-encoding.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: No auto encoding API
+version: v1
+baseUri: http://{baseUri}
+baseUriParameters:
+  (no-auto-encoding):
+  baseUri:
+    (no-auto-encoding):
+    enum:
+      - "example.org/v1"
+      - "example-int.org/v2"
+      - "example.org/v2"
+
+/entity:
+  get:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-view-model-transformer",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-view-model-transformer",
   "description": "AMF model transformer to a form view model used in API components.",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiViewModel.js
+++ b/src/ApiViewModel.js
@@ -1446,7 +1446,7 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
       return false;
     }
     for (let i = 0, len = values.length; i < len; i++) {
-      const id = /** @type string */ (this._getValue(values[i], '@id'));
+      const id = this._ensureAmfPrefix(/** @type string */ (this._getValue(values[i], '@id')));
       const node = shape[id];
       const extensionNameKey = this._getAmfKey(this.ns.aml.vocabularies.core.extensionName);
       if (this._getValue(node, extensionNameKey) === 'no-auto-encoding') {
@@ -1454,5 +1454,12 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
       }
     }
     return false;
+  }
+
+  _ensureAmfPrefix(id) {
+    if (!id.startsWith('amf://id')) {
+      return `amf://id${id}`;
+    }
+    return id;
   }
 }

--- a/src/ApiViewModel.js
+++ b/src/ApiViewModel.js
@@ -382,7 +382,7 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
       schemaItem.pattern = this._computeModelPattern(
         schemaItem.type, schemaItem.pattern, schemaItem.format);
       schemaItem.isNillable = schemaItem.type === 'union' ? this._computeIsNillable(def) : false;
-      schemaItem.noAutoEncode = this._computeNoAutoEncode(schema);
+      schemaItem.noAutoEncode = this._hasNoAutoEncodeProperty(schema);
     }
     if (this.noDocs) {
       result.hasDescription = false;
@@ -399,7 +399,7 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
       decodeValues: decodeValues
     };
     this._processAfterItemCreated(result, processOptions);
-    result.noAutoEncode = this._computeNoAutoEncode(amfItem);
+    result.noAutoEncode = this._hasNoAutoEncodeProperty(amfItem);
     // store cache
     appendGlobalValue(result);
     return result;
@@ -1436,7 +1436,7 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
    * @param {Object} shape An object to test for the annotation.
    * @return {boolean} True if the annotation is set.
    */
-  _computeNoAutoEncode(shape) {
+  _hasNoAutoEncodeProperty(shape) {
     if (!shape) {
       return false;
     }

--- a/src/ApiViewModel.js
+++ b/src/ApiViewModel.js
@@ -399,7 +399,7 @@ export class ApiViewModel extends AmfHelperMixin(Object) {
       decodeValues: decodeValues
     };
     this._processAfterItemCreated(result, processOptions);
-    result.autoEncode = this._computeNoAutoEncode(amfItem);
+    result.noAutoEncode = this._computeNoAutoEncode(amfItem);
     // store cache
     appendGlobalValue(result);
     return result;

--- a/test/ApiViewModel.test.js
+++ b/test/ApiViewModel.test.js
@@ -852,8 +852,8 @@ describe('ApiViewModel', function() {
       assert.isFalse(element._computeNoAutoEncode());
     });
 
-    it('Returns true if no-auto-encoding is present', () => {
-      assert.isTrue(element._computeNoAutoEncode(model));
+    it('Returns false if no-auto-encoding is present', () => {
+      assert.isFalse(element._computeNoAutoEncode(model));
     });
   });
 });

--- a/test/ApiViewModel.test.js
+++ b/test/ApiViewModel.test.js
@@ -834,13 +834,13 @@ describe('ApiViewModel', function() {
   describe('_computeNoAutoEncode()', () => {
     let element;
     const model = {
-      'amf': {
+      'amf://id': {
         'http://a.ml/vocabularies/core#extensionName': {
           '@value': 'no-auto-encoding'
         }
       },
       'http://a.ml/vocabularies/document#customDomainProperties': [{
-        '@id': 'amf'
+        '@id': 'amf://id'
       }]
     };
 
@@ -849,11 +849,11 @@ describe('ApiViewModel', function() {
     });
 
     it('Returns false if no value', () => {
-      assert.isFalse(element._computeNoAutoEncode());
+      assert.isFalse(element._hasNoAutoEncodeProperty());
     });
 
-    it('Returns false if no-auto-encoding is present', () => {
-      assert.isFalse(element._computeNoAutoEncode(model));
+    it('Returns true if no-auto-encoding is present', () => {
+      assert.isTrue(element._hasNoAutoEncodeProperty(model));
     });
   });
 });

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -174,4 +174,24 @@ AmfLoader.keyFor = function(amf, name) {
   return helper._getAmfKey(name);
 };
 
+AmfLoader.lookupServer = function(amf, serverUrl) {
+  helper.amf = amf;
+  let webApi = helper._computeWebApi(amf);
+  if (Array.isArray(webApi)) {
+    webApi = webApi[0];
+  }
+  const serverKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.server);
+  const servers = helper._ensureArray(webApi[serverKey]);
+  return servers.find(server => {
+    const urlTemplateKey = helper._getAmfKey(helper.ns.aml.vocabularies.core.urlTemplate);
+    return helper._getValue(server, urlTemplateKey) === serverUrl;
+  });
+}
+
+AmfLoader.getVariable = function(amf, model) {
+  helper.amf = amf;
+  const vKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.variable);
+  return model[vKey];
+}
+
 AmfLoader.ns = () => helper.ns;

--- a/test/amf-model.test.js
+++ b/test/amf-model.test.js
@@ -161,6 +161,17 @@ describe('<api-view-model-transformer>', function() {
             assert.isUndefined(schema.pattern, 'pattern is set');
             assert.equal(schema.type, 'string', 'type is set');
           });
+
+          it('computes model with noAutoEncode set to true', async () => {
+            const amf = await AmfLoader.load(/** @type boolean */ (item[1]), 'no-auto-encoding');
+            element = await basicFixture();
+            element.amf = amf;
+            const server = AmfLoader.lookupServer(amf, 'http://{baseUri}');
+            const variable = AmfLoader.getVariable(amf, server);
+            const result = element.computeViewModel(variable);
+            assert.lengthOf(result, 1);
+            assert.isTrue(result[0].noAutoEncode);
+          });
         });
 
         describe('Nil values', () => {


### PR DESCRIPTION
- Fix result generation: `result.autoEncode` -> `result.noAutoEncodes`
- Ensure amf prefix when checking for id references in shape